### PR TITLE
ENG-11515: [Adapter] Load the viewer loader if it is not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ var cfg =
 		, svcGlympse: *string*
 		, svcCards: *string*
 		, dbg: *bool*
+		, loaderEnvironment: *string*
+        , loaderPath: *string*
+        , loaderVersion: *string*
 	}
 };
 ```
@@ -143,6 +146,9 @@ var cfg =
   `//api.cards.glympse.com/api/v1/`.
   - `dbg`: Enable debugging state. Defaults to `false`.
   - `card`, `t`, `g`, `twt`, `pg`: Standard Cards/Glympse invite types.
+  - `loaderEnvironment`: Environment for the viewer's loader: "prod" (glympse.com) | "sandbox" (dev.glympse.com). Default is "prod".
+  - `loaderVersion`: Version of the viewer's loader. Default is "latest".
+  - `loaderPath`: Arbitrary URL to the loader (overrides `loaderEnvironment` and `loaderVersion`). Default is NULL.
 
 
 ### Custom Marker Configuration

--- a/app/src/GlympseAdapter.js
+++ b/app/src/GlympseAdapter.js
@@ -66,7 +66,7 @@ define(function(require, exports, module)
 		{
 			if (!glympserLoader)
 			{
-				dbg('adapter must be initialized in in client mode first', null, 3);
+				dbg('adapter must be initialized in client mode first', null, 3);
 				return;
 			}
 			glympserLoader.done(function()

--- a/app/src/GlympseAdapterDefines.js
+++ b/app/src/GlympseAdapterDefines.js
@@ -151,6 +151,15 @@ define(function(require, exports, module)
 		window.glympse = {};
 	}
 
+	if (!window.glympse.broadcastTypes)
+	{
+		window.glympse.broadcastTypes = {
+			DATA: 'DATA',
+			ETA: 'ETA',
+			INVITE_STATUS: 'INVITE_STATUS'
+		};
+	}
+
 	if (!window.glympse.GlympseAdapterDefines)
 	{
 		window.glympse.GlympseAdapterDefines = Defines;


### PR DESCRIPTION
@Glympse/web, PTAL.

@j5kay, is glympser loader is required only for client mode of adapter? In this case I'll need to start loading it in "_adapter.client_" call.

One more thing: as this is async loading, we will need to wait "AdapterInit" event to be able to call any adapter api (map/cards/core).