### PR TITLE
ENG-11516: Account credentials check

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,7 +655,7 @@ client-mode. These are also specifed in `GlympseAdapterDefines.CORE.REQUESTS_LOC
 - `getUserInfo(userId: string)`: Gets info for the current logged in user (name, avatar URL, etc.).
  If the optional `userId` param is non-null, info is retrieved for the specified user instead.
 - `hasAccount()`: Checks if the adapter has credentials for the currently configured API key.
- Synchronous method. Returns `false` for anonymous mode
+ Synchronous method. Returns `false` for anonymous mode, or if no credentials are found.
 - `setUserAvatar(imageUrlOrArrayBuffer: string|arraybuffer)`: Sets avatar to user, sends `UserAvatarUpdateStatus`
 - `setUserName(name: string)`: Sets name to user, sends `UserAvatarUpdateStatus`
 

--- a/README.md
+++ b/README.md
@@ -654,6 +654,8 @@ client-mode. These are also specifed in `GlympseAdapterDefines.CORE.REQUESTS_LOC
 - `accountCreate()`: Creates account, sends event `AccountCreateStatus` as a result.
 - `getUserInfo(userId: string)`: Gets info for the current logged in user (name, avatar URL, etc.).
  If the optional `userId` param is non-null, info is retrieved for the specified user instead.
+- `hasAccount()`: Checks if the adapter has credentials for the currently configured API key.
+ Synchronous method. Returns `false` for anonymous mode
 - `setUserAvatar(imageUrlOrArrayBuffer: string|arraybuffer)`: Sets avatar to user, sends `UserAvatarUpdateStatus`
 - `setUserName(name: string)`: Sets name to user, sends `UserAvatarUpdateStatus`
 

--- a/app/src/GlympseAdapterDefines.js
+++ b/app/src/GlympseAdapterDefines.js
@@ -97,6 +97,7 @@ define(function(require, exports, module)
 				, getUserInfo: 'getUserInfo'
 				, setUserName: 'setUserName'
 				, setUserAvatar: 'setUserAvatar'
+				, hasAccount: 'hasAccount'
 			}
 		}
 

--- a/app/src/adapter/Client.js
+++ b/app/src/adapter/Client.js
@@ -532,7 +532,7 @@ define(function(require, exports, module)
 		{
 			return function(data)
 			{
-				return (targ.cmd(id, data) || true);
+				return targ.cmd(id, data);
 			};
 		}
 

--- a/app/src/adapter/CoreController.js
+++ b/app/src/adapter/CoreController.js
@@ -87,6 +87,11 @@ define(function(require, exports, module)
 					account.getUserInfo(args);
 					break;
 				}
+
+				case rl.hasAccount:
+				{
+					return account.hasAccount();
+				}
 			}
 		};
 

--- a/app/src/adapter/models/Account.js
+++ b/app/src/adapter/models/Account.js
@@ -246,7 +246,7 @@ define(function(require, exports, module)
 			}
 		};
 
-		this.hasAccount = function ()
+		this.hasAccount = function()
 		{
 			getSettings();
 

--- a/app/src/adapter/models/Account.js
+++ b/app/src/adapter/models/Account.js
@@ -63,12 +63,8 @@ define(function(require, exports, module)
 
 		this.init = function()
 		{
-			settings = lib.getCfgVal(cAccountInfo) || {};
+			getSettings();
 
-			currentEnvKeys = settings[idEnvironment] || {};
-			currentKeySettings = currentEnvKeys[apiKey] || {};
-
-			//dbg('isAnon = ' + isAnon + ', settings', settings);
 			cfg.isAnon = isAnon;
 
 			token = currentKeySettings[cAcctTokenName];
@@ -250,6 +246,13 @@ define(function(require, exports, module)
 			}
 		};
 
+		this.hasAccount = function ()
+		{
+			getSettings();
+
+			return !!(!isAnon && currentKeySettings[cUserName] && currentKeySettings[cPassword]);
+		};
+
 
 		///////////////////////////////////////////////////////////////////////////////
 		// UTILITY
@@ -260,6 +263,13 @@ define(function(require, exports, module)
 			currentEnvKeys[apiKey] = currentKeySettings;
 			settings[idEnvironment] = currentEnvKeys;
 			lib.setCfgVal(cAccountInfo, settings);
+		}
+
+		function getSettings()
+		{
+			settings = lib.getCfgVal(cAccountInfo) || {};
+			currentEnvKeys = settings[idEnvironment] || {};
+			currentKeySettings = currentEnvKeys[apiKey] || {};
 		}
 
 		function getNewToken()


### PR DESCRIPTION
@Glympse/web PTAL
Added `core.hasAccount()` method to check if adapter has creds for current API key. Returns `false` for anonymous mode