### PR TITLE
ENG-11513: Added core.accountDelete() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,8 @@ using GA in host-mode) that are sent by the adapter (defined in the
   creation failed with `error` message and `status: false`
 - `AccountLoginStatus` / `{ status: bool }`: `status: true` - Indicates the adapter successfully
   logged in. `status: false` - Error occurred, property `error` has additional info about it
+- `AccountDeleteStatus` / `{ status: bool }`: `status: true` - Indicates the adapter successfully
+  removed current credentials.
 - `AdapterInit` / `{ isCard: bool, t: string }`: Indicates the adapter is beginning
   its loading sequence with the passed card invite or the specified Glympse invite
   (indicated via the `t` parameter)
@@ -665,6 +667,7 @@ The following APIs are only available to consumers of the GA when running in
 client-mode. These are also specifed in `GlympseAdapterDefines.CORE.REQUESTS_LOCAL`:
 
 - `accountCreate()`: Creates account, sends event `AccountCreateStatus` as a result.
+- `accountDelete()`: Removes account, sends event `AccountDeleteStatus` as a result.
 - `getUserInfo(userId: string)`: Gets info for the current logged in user (name, avatar URL, etc.).
  If the optional `userId` param is non-null, info is retrieved for the specified user instead.
 - `hasAccount()`: Checks if the adapter has credentials for the currently configured API key.

--- a/app/src/GlympseAdapterDefines.js
+++ b/app/src/GlympseAdapterDefines.js
@@ -98,6 +98,7 @@ define(function(require, exports, module)
 
 			, REQUESTS_LOCAL: {
 				accountCreate: 'accountCreate'
+				, accountDelete: 'accountDelete'
 				, generateAuthToken: 'generateAuthToken'
 				, getUserInfo: 'getUserInfo'
 				, setUserName: 'setUserName'
@@ -115,6 +116,7 @@ define(function(require, exports, module)
 		, MSG: {
 			//Account Events
 			  AccountCreateStatus: 'AccountCreateStatus'
+			, AccountDeleteStatus: 'AccountDeleteStatus'
 		    , AccountLoginStatus: 'AccountLoginStatus'
 			, UserNameUpdateStatus: 'UserNameUpdateStatus'
 			, UserAvatarUpdateStatus: 'UserAvatarUpdateStatus'

--- a/app/src/adapter/CardsController.js
+++ b/app/src/adapter/CardsController.js
@@ -15,7 +15,6 @@ define(function(require, exports, module)
 	var Account = require('glympse-adapter/adapter/models/Account');
 	var Card = require('glympse-adapter/adapter/models/Card');
 
-
 	// Exported class
 	function CardsController(controller, cfg)
 	{
@@ -23,6 +22,7 @@ define(function(require, exports, module)
 		var dbg = lib.dbg('CardsController', cfg.dbg);
 		var svr = (cfg.svcCards || '//api.cards.glympse.com/api/v1/');
 		var pollInterval = cfg.pollCards || 60000;
+		var pollingInterval;
 		var cardsMode = cfg.cardsMode;
 
 		// state
@@ -67,6 +67,12 @@ define(function(require, exports, module)
 					authToken = args.token;
 					accountId = args.id;
 					accountInitComplete(args);
+					break;
+				}
+
+				case m.AccountDeleteStatus:
+				{
+					accountDeleteComplete();
 					break;
 				}
 
@@ -177,7 +183,17 @@ define(function(require, exports, module)
 			if (cardsMode)
 			{
 				requestCards();
-				setInterval(requestCards, pollInterval);
+				pollingInterval = setInterval(requestCards, pollInterval);
+			}
+		}
+
+		function accountDeleteComplete(){
+			authToken = null;
+			accountId = null;
+			if (pollingInterval)
+			{
+				clearInterval(pollingInterval);
+				pollingInterval = null;
 			}
 		}
 

--- a/app/src/adapter/Client.js
+++ b/app/src/adapter/Client.js
@@ -415,7 +415,7 @@ define(function(require, exports, module)
 						}
 					}
 
-					sendEvent(m.AccountLoginStatus, args);
+					sendEvent(msg, args);
 
 					if (!initialized && args.status)
 					{
@@ -425,6 +425,22 @@ define(function(require, exports, module)
 
 					break;
 				}
+
+				case m.AccountDeleteStatus:
+
+					if (glympseLoader)
+					{
+						glympseLoader.notify(msg, args);
+					}
+
+					if (cardsController)
+					{
+						cardsController.notify(msg, args);
+					}
+
+					sendEvent(msg, args);
+
+					break;
 
 				case m.AccountCreateStatus:
 				case m.CreateRequestStatus:

--- a/app/src/adapter/CoreController.js
+++ b/app/src/adapter/CoreController.js
@@ -35,6 +35,7 @@ define(function(require, exports, module)
 			switch (msg)
 			{
 				case m.AccountLoginStatus:
+				case m.AccountDeleteStatus:
 				case m.AccountCreateStatus:
 				case m.UserNameUpdateStatus:
 				case m.UserAvatarUpdateStatus:
@@ -96,7 +97,14 @@ define(function(require, exports, module)
 
 				case rl.createRequest:
 				{
-					return account.createRequest(args);
+					account.createRequest(args);
+					break;
+				}
+
+				case rl.accountDelete:
+				{
+					account.delete();
+					break;
 				}
 			}
 		};

--- a/app/src/adapter/GlympseLoader.js
+++ b/app/src/adapter/GlympseLoader.js
@@ -49,7 +49,17 @@ define(function(require, exports, module)
 				case m.AccountLoginStatus:
 				{
 					authToken = args.token;
-					accountInitComplete(authToken, args);
+					accountInitComplete(args);
+					break;
+				}
+
+				case m.AccountDeleteStatus:
+				{
+					authToken = null;
+					if (invite)
+					{
+						invite.setToken(authToken);
+					}
 					break;
 				}
 
@@ -96,7 +106,7 @@ define(function(require, exports, module)
 		// UTILITY
 		///////////////////////////////////////////////////////////////////////////////
 
-		function accountInitComplete(token, info)
+		function accountInitComplete(info)
 		{
 			var sig = '[accountInitComplete] - ';
 

--- a/app/src/adapter/models/Account.js
+++ b/app/src/adapter/models/Account.js
@@ -325,6 +325,12 @@ define(function(require, exports, module)
 			}
 		};
 
+		this.delete = function() {
+			//delete all storages for this account
+			deleteSettings();
+
+			controller.notify(m.AccountDeleteStatus, { status: true });
+		};
 
 		///////////////////////////////////////////////////////////////////////////////
 		// UTILITY
@@ -342,6 +348,12 @@ define(function(require, exports, module)
 			settings = lib.getCfgVal(cAccountInfo) || {};
 			currentEnvKeys = settings[idEnvironment] || {};
 			currentKeySettings = currentEnvKeys[apiKey] || {};
+		}
+
+		function deleteSettings() {
+			getSettings();
+			currentKeySettings = {};
+			saveSettings();
 		}
 
 		function getNewToken()


### PR DESCRIPTION
- Added `core.accountDelete()` endpoint
- Added event `AccountDeleteStatus` instead of `AccountDeleted` to be consistent with other event names

@Glympse/web PTAL