### PR TITLE
send status of cards request

### DIFF
--- a/app/src/GlympseAdapterDefines.js
+++ b/app/src/GlympseAdapterDefines.js
@@ -132,6 +132,7 @@ define(function(require, exports, module)
 			, CardUpdated: 'CardUpdated'
 			, CardAdded: 'CardAdded'
 			, CardRemoved: 'CardRemoved'
+			, CardsRequestStatus: 'CardsRequestStatus'
 			, CardsJoinRequestStatus: 'CardsJoinRequestStatus'
 			, CardsJoinRequestCancelStatus: 'CardsJoinRequestCancelStatus'
 			, CardsActiveJoinRequestsStatus: 'CardsActiveJoinRequestsStatus'

--- a/app/src/adapter/CardsController.js
+++ b/app/src/adapter/CardsController.js
@@ -629,7 +629,9 @@ define(function(require, exports, module)
 					if (data.result === 'ok')
 					{
 						result.status = true;
-						result.response = data.response;
+						result.response = data.response || {};
+						result.response.cardId = config.cardId;
+						result.response.memberId = memberId;
 
 						requestCards();
 					}

--- a/app/src/adapter/Client.js
+++ b/app/src/adapter/Client.js
@@ -436,6 +436,7 @@ define(function(require, exports, module)
 				case m.CardsActiveJoinRequestsStatus:
 				case m.CardRemoveMemberStatus:
 				case m.CardsLocationRequestStatus:
+				case m.CardsRequestStatus:
 				{
 					sendEvent(msg, args);
 					break;


### PR DESCRIPTION
We had only `CardAdded`/`CardRemoved` events before, so there was no way to distinguish between cases when user has no cards or we just not received response on cards request.

@Glympse/web, PTAL.