### PR TITLE
Fixed for the case when member left the group

### DIFF
--- a/app/src/adapter/models/Card.js
+++ b/app/src/adapter/models/Card.js
@@ -134,7 +134,7 @@ define(function(require, exports, module)
 						newMembers.push(action.data.member_id);
 						break;
 					case 'member_removed':
-						member = removeMemberById(action.data.member_id);
+						member = removeMemberById(action.data ? action.data.member_id : action.member_id);
 						updateResult.member = member;
 						controller.notify(m.CardUpdated, updateResult);
 						break;


### PR DESCRIPTION
@Glympse/web PTAL

Response of `member_removed` action includes `data` property only if two members involve in that action (member was kicked from the group)