### PR TITLE
[ENG-11990] Need to send request id after successful cancelling

### DIFF
--- a/app/src/adapter/CardsController.js
+++ b/app/src/adapter/CardsController.js
@@ -448,6 +448,10 @@ define(function(require, exports, module)
 			ajax.delete(url, account)
 				.then(function(result)
 				{
+					if (result.status)
+					{
+						result.response.id = requestId;
+					}
 					controller.notify(m.CardsJoinRequestCancelStatus, result);
 				});
 		}

--- a/app/src/adapter/models/Card.js
+++ b/app/src/adapter/models/Card.js
@@ -149,11 +149,13 @@ define(function(require, exports, module)
 						member = getMemberById(action.member_id);
 						member.setData(action.data);
 						updateResult.invite = checkMemberInviteCode(member);
+						updateResult.userId = action.user_id;
 						controller.notify(m.CardUpdated, updateResult);
 						break;
 					case 'member_stopped_sharing':
 						member = getMemberById(action.member_id);
 						updateResult.invite = removeMemberInviteCode(member);
+						updateResult.userId = action.user_id;
 						controller.notify(m.CardUpdated, updateResult);
 						break;
 


### PR DESCRIPTION
@Glympse/web PTAL

Need to send requireId in the response to validate a request, for the case when we send more than one cancel request

Also added userId in start/stop sharing events