### PR TITLE
ENG-12042: Mark card for forced updating when we got card_modified

### DIFF
--- a/app/src/adapter/CardsController.js
+++ b/app/src/adapter/CardsController.js
@@ -216,7 +216,7 @@ define(function(require, exports, module)
 
 			return {
 				card: card,
-				request: isNew ? getCard(card) : updateCard(card)
+				request: (isNew || card.dirty) ? getCard(card) : updateCard(card)
 			};
 		}
 
@@ -321,7 +321,7 @@ define(function(require, exports, module)
 
 			return {
 				name: 'getCard',
-				url: cardUrl + '?' +  $.param({members: true}),
+				url: cardUrl + '?' +  $.param({members: !card.dirty}),
 				method: 'GET'
 			};
 		}
@@ -355,9 +355,14 @@ define(function(require, exports, module)
 			if (result.status)
 			{
 				//dbg('Got card data', resp);
+
 				card.setData(result.response);
-				card.setLastUpdatingTime(result.time);
-				that.notify(m.CardReady, idCard);
+				if(!card.dirty) {
+					card.setLastUpdatingTime(result.time);
+					that.notify(m.CardReady, idCard);
+				} else {
+					card.dirty = false;
+				}
 			}
 			else if (result.response.error === 'failed_to_decode')
 			{

--- a/app/src/adapter/models/Card.js
+++ b/app/src/adapter/models/Card.js
@@ -156,7 +156,11 @@ define(function(require, exports, module)
 						updateResult.userId = action.user_id;
 						controller.notify(m.CardUpdated, updateResult);
 						break;
-
+					case 'card_modified':
+						//mark to update on next poll
+						this.dirty = true;
+						controller.notify(m.CardUpdated, updateResult);
+						break;
 					default:
 						updateResult.data = action;
 						controller.notify(m.CardUpdated, updateResult);


### PR DESCRIPTION
@Glympse/web PTAL

`card_modified` action doesn't have any data what exactly was modified, so card has been marked to update with next activity poll