### PR TITLE
add invitee getter to card model

### DIFF
--- a/app/src/adapter/models/Card.js
+++ b/app/src/adapter/models/Card.js
@@ -42,6 +42,7 @@ define(function(require, exports, module)
 			, 'id'
 			, 'metadata_etag'
 			, 'inviter'
+			, 'invitee'
 			, 'details'
 		];
 


### PR DESCRIPTION
Necessary for FE-234: Viewer does not handle Request to Join Card (card_request) links.

@Glympse/web, PTAL.