### PR TITLE
Fix event not bubbling up if no card

### DIFF
--- a/app/src/adapter/Client.js
+++ b/app/src/adapter/Client.js
@@ -232,7 +232,8 @@ define(function(require, exports, module)
 					, val: val
 				};
 
-				sendEvent(mStateUpdate, info, false);
+				notifyApp(mStateUpdate, info, false);
+				sendOasisMessage(mStateUpdate, info);
 			}
 		};
 
@@ -619,10 +620,10 @@ define(function(require, exports, module)
 			app.notify(msg, args);
 		}
 
-		function sendEvent(msg, args, evtMsg)
+		function sendEvent(msg, args)
 		{
 			sendOasisMessage(msg, args);
-			notifyApp(msg, args, (evtMsg || true));
+			notifyApp(msg, args, true);
 		}
 
 

--- a/app/src/adapter/Client.js
+++ b/app/src/adapter/Client.js
@@ -221,7 +221,7 @@ define(function(require, exports, module)
 			var info, i;
 			var targetCardsLength = targetCards.length;
 			// send event for each card (same user can share same inviteCode to different cards)
-			for (i = (!!targetCardsLength) ? targetCardsLength - 1 : 0; i >= 0; i--)
+			for (i = (targetCardsLength) ? targetCardsLength - 1 : 0; i >= 0; i--)
 			{
 				info = {
 					id: id

--- a/app/src/adapter/Client.js
+++ b/app/src/adapter/Client.js
@@ -219,8 +219,9 @@ define(function(require, exports, module)
 
 			var targetCards = mapCardTicketInvites[invite] || [];
 			var info, i;
+			var targetCardsLength = targetCards.length;
 			// send event for each card (same user can share same inviteCode to different cards)
-			for (i = targetCards.length - 1; i >= 0; i--)
+			for (i = (!!targetCardsLength) ? targetCardsLength - 1 : 0; i >= 0; i--)
 			{
 				info = {
 					id: id
@@ -231,8 +232,7 @@ define(function(require, exports, module)
 					, val: val
 				};
 
-				notifyApp(mStateUpdate, info, false);
-				sendOasisMessage(mStateUpdate, info);
+				sendEvent(mStateUpdate, info, false);
 			}
 		};
 
@@ -619,10 +619,10 @@ define(function(require, exports, module)
 			app.notify(msg, args);
 		}
 
-		function sendEvent(msg, args)
+		function sendEvent(msg, args, evtMsg)
 		{
 			sendOasisMessage(msg, args);
-			notifyApp(msg, args, true);
+			notifyApp(msg, args, (evtMsg || true));
 		}
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glympse-adapter",
   "description": "Web-based adapter for handling various Glympse-related functionality",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "homepage": "https://github.com/Glympse/glympse-adapter",
   "license": "BSD-Protection",
   "authors": [


### PR DESCRIPTION
I'm expecting that there's a better fix since I don't know all the logic around `mapCardTicketInvites`, but here's a crack at fixing journey not updating phase.

Issue stems from targetCardsLength being 0 and `sendEvent` not firing when it's not a card invite.

Also updated `sendEvent()` to allow for passing in evtMsg false. true by default.

@j5kay , PTAL