### PR TITLE
fixed `card.activity` api

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ using GA in host-mode) that are sent by the adapter (defined in the
   creation failed with `response.error` message and `status: false`
 - `CardsJoinRequestCancelStatus`: Indicates that Card join request has been cancelled or
   cancelling failed with `response.error` message and `status: false`
+- `CardActivityStatus`: Returns the list of card activities for the requested period
 - `CardsActiveJoinRequestsStatus`: Returns the list of active join card requests in `response` property
 - `CardRemoveMemberStatus`: Indicates that Card member was removed or removing failed with `response.error` message and `status: false`
 - `CardsLocationRequestStatus`: Indicates that location request was created or creation failed with `response.error` message and `status: false`
@@ -728,7 +729,7 @@ Access to these endpoints can be made via the `cards` property of the adapter in
   - `config.cardId`: Card id to send request
   - `config.memberList`: List of member_ids to send requests. Not used if scope = "all".
 - `activity(config)`: Requests card's activities for the specified period ([read more](https://developer.glympse.com/docs/core/api/reference/cards/id/activity/get)). 
-  Can send a number of `CardUpdated` events as appropriate (Read more about this event [here](#adapter-messagesevents)).
+  Returns `CardActivityStatus` with the list of activities (Read more about this event [here](#adapter-messagesevents)).
   - `config.cardId`: Card id to request activities
   - `config.fromTS`: start timestamp
   - `config.toTS`: end timestamp

--- a/app/src/GlympseAdapterDefines.js
+++ b/app/src/GlympseAdapterDefines.js
@@ -138,6 +138,7 @@ define(function(require, exports, module)
 			, CardsRequestStatus: 'CardsRequestStatus'
 			, CardsJoinRequestStatus: 'CardsJoinRequestStatus'
 			, CardsJoinRequestCancelStatus: 'CardsJoinRequestCancelStatus'
+			, CardActivityStatus: 'CardActivityStatus'
 			, CardsActiveJoinRequestsStatus: 'CardsActiveJoinRequestsStatus'
 			, CardRemoveMemberStatus: 'CardRemoveMemberStatus'
 			, CardsLocationRequestStatus: 'CardsLocationRequestStatus'

--- a/app/src/adapter/CardsController.js
+++ b/app/src/adapter/CardsController.js
@@ -615,7 +615,8 @@ define(function(require, exports, module)
 				});
 		}
 
-		function getCardActivity(config) {
+		function getCardActivity(config)
+		{
 			if (!config || !config.cardId)
 			{
 				dbg('CardId param is mandatory!', config, 3);
@@ -623,14 +624,32 @@ define(function(require, exports, module)
 			}
 
 			var cardId = config.cardId,
-				card = cardsIndex[cardId],
-				fromTS = config.fromTS,
-				toTS = config.toTS;
+				card = cardsIndex[cardId];
 
-			if (card)
+			if (!card)
 			{
-				updateCard(card, fromTS, toTS);
+				dbg('Card with id=' + cardId + ' not found!', config, 3);
+				return;
 			}
+
+			var requestConfig = updateCard(card, config.fromTS, config.toTS);
+
+			ajax.makeRequest(
+				{
+					url: (svr + requestConfig.url),
+					type: requestConfig.method
+				},
+				account
+			)
+				.then(function(result)
+				{
+					if (result.status)
+					{
+						result.cardId = cardId;
+					}
+
+					controller.notify(m.CardActivityStatus, result);
+				});
 		}
 	}
 

--- a/app/src/adapter/Client.js
+++ b/app/src/adapter/Client.js
@@ -487,6 +487,7 @@ define(function(require, exports, module)
 				case m.UserInfoStatus:
 				case m.CardsJoinRequestStatus:
 				case m.CardsJoinRequestCancelStatus:
+				case m.CardActivityStatus:
 				case m.CardsActiveJoinRequestsStatus:
 				case m.CardRemoveMemberStatus:
 				case m.CardsLocationRequestStatus:


### PR DESCRIPTION
- the mentioned api was not doing anything
- now it emits `CardActivityStatus` event with activities for the requested period

@Glympse/web, PTAL.