### PR TITLE
FE-822 Add handling for viewer invite_error and oauth token err

### DIFF
--- a/app/src/GlympseAdapterDefines.js
+++ b/app/src/GlympseAdapterDefines.js
@@ -150,6 +150,7 @@ define(function(require, exports, module)
 			, InviteInit: 'InviteInit'
 			, InviteReady: 'InviteReady'
 			, InviteRemoved: 'InviteRemoved'
+			, OauthError: 'OauthError'
 			, Progress: 'Progress'
 			, StateUpdate: 'StateUpdate'
 			, ViewerInit: 'ViewerInit'

--- a/app/src/adapter/ViewerMonitor.js
+++ b/app/src/adapter/ViewerMonitor.js
@@ -73,6 +73,8 @@ define(function(require, exports, module)
 			viewerElement.addEventListener(glyEvents.INVITE_ADDED, viewerInviteAdded, false);
 			viewerElement.addEventListener(glyEvents.INVITE_REMOVED, viewerInviteRemoved, false);
 			viewerElement.addEventListener(glyEvents.INVITE_CLICKED, viewerInviteClicked, false);
+			viewerElement.addEventListener(glyEvents.INVITE_ERROR, viewerInviteError, false);
+			viewerElement.addEventListener(glyEvents.OAUTH_TOKEN_ERROR, viewerOauthTokenError, false);
 		};
 
 		this.shutdown = function()
@@ -332,6 +334,16 @@ define(function(require, exports, module)
 			//dbg('InviteClicked', e.detail);
 			e.detail.data = undefined;
 			controller.notify(m.InviteClicked, e.detail);
+		}
+
+		function viewerInviteError(e)
+		{
+			controller.notify(m.InviteError, e.detail);
+		}
+
+		function viewerOauthTokenError(e)
+		{
+			controller.notify(m.OauthError, e.detail);
 		}
 
 


### PR DESCRIPTION
@j5kay not sure why the event.detail.data were being set to undefined for the other viewer invite events, can you clarify? 

If that's needed for these events I can add them in

FE-822