### PR TITLE
FE-851: Public group updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,39 @@ using GA in host-mode) that are sent by the adapter (defined in the
   - `n`: Property id
   - `v`: Property value (may be default type, or a custom Object with additional
   members)
+- `GroupLoaded`: Generated after an `addGroup` command is sent to the `core` endpoint, with information
+  about the just-loaded Glympse public group. For normal responses, the `args` payload will look something
+  like:
+  ```
+  {
+    "status": true,
+    "response": {
+      "type": "group",
+      "id": 119,
+      "events": 1,
+      "members": [
+        {
+          "id": "DNA7-4HDZ-03WH0",
+          "invite": "demobot0"
+        }
+      ],
+      "public": true,
+      "name": "DemoShuttle"
+    },
+    "time": 1499192505285,
+    "group": "demoshuttle",
+    "invitesAdded": [
+      "demobot0"
+    ],
+    "invitesRemoved": [],
+    "invitesSwapped": []
+  }
+  ```
+- `GroupResponse`: Seen periodically after a public group has been added to the adapter. This event
+  will contain updates to the group after initial load. Main usage will be in examining the contents
+  of the `invitesAdded`, `invitesRemoved`, and `invitesSwapped` arrays, which will be the updates since
+  initial load. Note that this event data will be identical to the initial `GroupLoaded` event for the
+  first `GroupResponse` event seen. See `GroupLoaded` for expected data format.
 - `InviteAdded` / `{ id: glympse_invite_code, owner: glympse_user_account_id, card: card_id }`:
   Sent from the Glympse viewer whenever a Glympse invite has been successfully
   loaded and added to the map.
@@ -702,6 +735,17 @@ client-mode. These are also specifed in `GlympseAdapterDefines.MAP.REQUESTS_LOCA
 - `ignoreDestinations(bool)`: Hides current invite destinations. Returns a list of all
   affected destination objects.
 
+
+### GlympseAdapter.core.* endpoints (host/client-mode):
+Below is a list of all of the exposed GA APIs with respect to the core Glympse API,
+and available to either host or client-based consumers. These endpoints are also
+specified in `GlympseAdapterDefines.CORE.REQUESTS`.
+
+- `addGroup(groupInfo: string|object)`: Creates a Glympse "public" group request for viewing.
+  `groupInfo` can specify the group id to load (if it is a string type), or the response of
+  an initial groups request (if it is an object type).
+- `getGroup(groupId: string)`: [NOT AVAILABLE]
+- `removeGroup(groupId: string)`: [NOT AVAILABLE]
 
 ### GlympseAdapter.core.* endpoints (client-mode-only):
 The following APIs are only available to consumers of the GA when running in

--- a/app/src/GlympseAdapterDefines.js
+++ b/app/src/GlympseAdapterDefines.js
@@ -84,24 +84,6 @@ define(function(require, exports, module)
 			}
 		}
 
-		, PUBLIC_GROUPS: {
-
-			/////////////////////////////////////////
-			// API Endpoints - host and client
-			/////////////////////////////////////////
-
-			REQUESTS: {
-			}
-
-
-			/////////////////////////////////////////
-			// API Endpoints: client-only
-			/////////////////////////////////////////
-
-			, REQUESTS_LOCAL: {
-			}
-		}
-
 		, CORE: {
 
 			/////////////////////////////////////////
@@ -109,6 +91,9 @@ define(function(require, exports, module)
 			/////////////////////////////////////////
 
 			REQUESTS: {
+				addGroup: 'addGroup'
+				, getGroup: 'getGroup'
+				, removeGroup: 'removeGroup'
 			}
 
 
@@ -162,9 +147,9 @@ define(function(require, exports, module)
 			, CardRemoveMemberStatus: 'CardRemoveMemberStatus'
 			, CardsLocationRequestStatus: 'CardsLocationRequestStatus'
 
-			//Public group events
-			, PG_Loaded: 'PG_Loaded'
-			, PG_RequestStatus: 'PG_RequestStatus'
+			// Public group events
+			, GroupLoaded: 'GroupLoaded'
+			, GroupStatus: 'GroupStatus'
 
 			, DataUpdate: 'DataUpdate'
 			, InviteAdded: 'InviteAdded'

--- a/app/src/adapter/Client.js
+++ b/app/src/adapter/Client.js
@@ -348,6 +348,11 @@ define(function(require, exports, module)
 				case m.InviteError:
 				{
 					//dbg('Invite loading error', args);
+					if (args.data.invite.toJSON)
+					{
+						args.data.invite = args.data.invite.toJSON();
+					}
+					
 					sendEvent(msg, args);
 					break;
 				}

--- a/app/src/adapter/Client.js
+++ b/app/src/adapter/Client.js
@@ -9,7 +9,6 @@ define(function(require, exports, module)
 	var Defines = require('glympse-adapter/GlympseAdapterDefines');
 	var ViewerMonitor = require('glympse-adapter/adapter/ViewerMonitor');
 	var CardsController = require('glympse-adapter/adapter/CardsController');
-	var PublicGroupController = require('glympse-adapter/adapter/PublicGroupController');
 	var CoreController = require('glympse-adapter/adapter/CoreController');
 	var GlympseLoader = require('glympse-adapter/adapter/GlympseLoader');
 	var Account = require('glympse-adapter/adapter/models/Account');
@@ -29,10 +28,9 @@ define(function(require, exports, module)
 		// state
 		var that = this;
 		var cardsController;
-		var publicGroupController;
 		var cfgMonitor = { dbg: cfgApp.dbg, viewer: elementViewer };
 		var invitesCard;
-		var invitesGlympse;
+		var invitesTicket;
 		var invitesReferences = {};
 		var glympseLoader;
 		var mapCardTicketInvites = {};
@@ -99,23 +97,21 @@ define(function(require, exports, module)
 			var cleanInvites = lib.cleanInvites;
 
 			invitesCard = (card) ? cleanInvites([ card ]) : [];
-			invitesGlympse = cleanInvites(splitMulti(t));
+			invitesTicket = cleanInvites(splitMulti(t));
 
 			events.setUserInfo = setUserInfo;	// Dummy/test
 
-			$.extend(settings, { invitesCard: invitesCard, invitesGlympse: invitesGlympse });
+			$.extend(settings, { invitesCard: invitesCard, invitesGlympse: invitesTicket });
 
 
 			coreController = new CoreController(this, cfgAdapter);
 			cardsController = new CardsController(this, cfgAdapter);
-			publicGroupController = new PublicGroupController(this, cfgAdapter);
 			viewerMonitor = new ViewerMonitor(this, cfgMonitor);
 
 			// API namespaced endpoints
 			var svcs = [
 				{ id: 'MAP', targ: viewerMonitor },
 				{ id: 'CARDS', targ: cardsController },
-				{ id: 'PUBLIC_GROUPS', targ: publicGroupController },
 				{ id: 'CORE', targ: coreController }
 			];
 
@@ -219,18 +215,19 @@ define(function(require, exports, module)
 			oasisLocal.connect(cfgClient);
 
 			// Notify of invite loading status
+			var pg = (cfgAdapter.pg || '');
+			var obj = (cfgAdapter.object || {});
 			var initSettings = {
 				isCard: (card !== null || cardsMode)
-				, t: invitesGlympse
-				, pg: splitMulti(cfgAdapter.pg)
+				, t: invitesTicket
+				, pg: splitMulti(pg + ((obj.group) ? (((pg) ? ';' : '') + obj.group) : ''))
 				, twt: splitMulti(cfgAdapter.twt)
 				, g: splitMulti(cfgAdapter.g)
-				, publicGroup: cfgAdapter.object && cfgAdapter.object.group
 			};
 
 			progressCurrent = 0;
 			progressTotal = (invitesCard.length > 0) ? (5 + 1 * 2) :
-				((invitesGlympse.length > 0) ? 3 : 0);
+							((invitesTicket.length > 0) ? 3 : 0);
 
 			sendEvent(m.AdapterInit, initSettings);
 			updateProgress();
@@ -477,10 +474,6 @@ define(function(require, exports, module)
 						{
 							cardsController.notify(msg, args);
 						}
-						if (publicGroupController)
-						{
-							publicGroupController.notify(msg, args);
-						}
 
 						// do not pass "account" to consumers
 						delete args.account;
@@ -498,7 +491,7 @@ define(function(require, exports, module)
 				}
 
 				case m.AccountDeleteStatus:
-
+				{
 					if (glympseLoader)
 					{
 						glympseLoader.notify(msg, args);
@@ -508,14 +501,10 @@ define(function(require, exports, module)
 					{
 						cardsController.notify(msg, args);
 					}
-					if (publicGroupController)
-					{
-						publicGroupController.notify(msg, args);
-					}
 
 					sendEvent(msg, args);
-
 					break;
+				}
 
 				case m.AccountCreateStatus:
 				case m.CreateRequestStatus:
@@ -534,9 +523,9 @@ define(function(require, exports, module)
 					break;
 				}
 
-				case m.PG_Loaded:
-                case m.PG_RequestStatus:
-                {
+				case m.GroupLoaded:
+				case m.GroupStatus:
+				{
 					sendEvent(msg, args);
 					break;
 				}
@@ -558,6 +547,8 @@ define(function(require, exports, module)
 
 		function loadInvites()
 		{
+			sendEvent(m.AdapterReady, { cards: invitesCard, tickets: invitesTicket });
+
 			// Various invite types handled by the map
 			var t = cfgAdapter.t;		// Core invite
 			var pg = cfgAdapter.pg;		// Core group (public)
@@ -571,33 +562,20 @@ define(function(require, exports, module)
 				return;
 			}
 
-			// Special handling to determine if a core invite has a card reference
-			// GlympseLoader will perform the lookup to determine if indeed there
-			// is a card invite to load instead of the presented core invite.
-			// FIXME: Assumes only one invite code!
-		//	if (lib.simplifyInvite(t).indexOf('demobot') < 0)
-		//	{
-		//		glympseLoader = new GlympseLoader(that, cfgAdapter);
-		//		glympseLoader.init(t);
-		//		return;
-		//	}
-
 			// During init, look for an object `object`, if it exists, and it has a member of "group",
 			// then use this as an initialization for a new Glympse public group to begin loading/parsing, bypassing the normal initial group load
 			var obj = cfgAdapter.object || {};
 			if (obj.group || pg)
 			{
 				//dbg('Initial group header received, start processing...', obj);
-
-				publicGroupController.init(obj.group || pg);
+				coreController.cmd(Defines.CORE.REQUESTS.addGroup, obj.group || pg);
 				return;
 			}
 
 			// Straight invite types to load
-			if (t || pg || g || twt)
+			if (t || g || twt)
 			{
 				cfgViewer.t = t;
-				cfgViewer.pg = pg;
 				cfgViewer.twt = twt;
 				cfgViewer.g = g;
 
@@ -608,8 +586,6 @@ define(function(require, exports, module)
 		function loadMap(cfgNew, newMapElement)
 		{
 			dbg('loadMap!');
-			// Signal the cards/invites to load
-			sendEvent(m.AdapterReady, {cards: invitesCard, glympses: invitesGlympse});
 
 			//console.log('cfg.viewer=' + cfgMonitor.viewer);
 			$.extend(cfgViewer, cfgNew);

--- a/app/src/adapter/Client.js
+++ b/app/src/adapter/Client.js
@@ -15,6 +15,7 @@ define(function(require, exports, module)
 
 	var s = Defines.STATE;
 	var m = Defines.MSG;
+	var coreReq = Defines.CORE.REQUESTS;
 	var mStateUpdate = m.StateUpdate;	// Used alot
 
 	function Client(controller, oasisLocal, app, cfg, elementViewer)
@@ -215,12 +216,11 @@ define(function(require, exports, module)
 			oasisLocal.connect(cfgClient);
 
 			// Notify of invite loading status
-			var pg = (cfgAdapter.pg || '');
 			var obj = (cfgAdapter.object || {});
 			var initSettings = {
 				isCard: (card !== null || cardsMode)
 				, t: invitesTicket
-				, pg: splitMulti(pg + ((obj.group) ? (((pg) ? ';' : '') + obj.group) : ''))
+				, pg: obj.group || splitMulti(cfgAdapter.pg)
 				, twt: splitMulti(cfgAdapter.twt)
 				, g: splitMulti(cfgAdapter.g)
 			};
@@ -573,7 +573,7 @@ define(function(require, exports, module)
 			if (obj.group || pg)
 			{
 				//dbg('Initial group header received, start processing...', obj);
-				coreController.cmd(Defines.CORE.REQUESTS.addGroup, obj.group || pg);
+				coreController.cmd(coreReq.addGroup, obj.group || pg);
 				return;
 			}
 

--- a/app/src/adapter/CoreController.js
+++ b/app/src/adapter/CoreController.js
@@ -7,9 +7,12 @@ define(function(require, exports, module)
 	var Defines = require('glympse-adapter/GlympseAdapterDefines');
 
 	var m = Defines.MSG;
+	var r = Defines.CORE.REQUESTS;
 	var rl = Defines.CORE.REQUESTS_LOCAL;
 
 	var Account = require('glympse-adapter/adapter/models/Account');
+	var GroupController = require('glympse-adapter/adapter/PublicGroupController');
+
 
 	// Exported class
 	function CoreController(controller, cfg)
@@ -19,6 +22,7 @@ define(function(require, exports, module)
 
 		// state
 		var account = new Account(this, cfg);
+		var groupController;
 
 
 		///////////////////////////////////////////////////////////////////////////////
@@ -35,12 +39,34 @@ define(function(require, exports, module)
 			switch (msg)
 			{
 				case m.AccountLoginStatus:
+				{
+					if (args.status && groupController)
+					{
+						groupController.notify(msg, args);
+					}
+
+					controller.notify(msg, args);
+					break;
+				}
+
 				case m.AccountDeleteStatus:
+				{
+					if (groupController)
+					{
+						groupController.notify(msg, args);
+					}
+
+					controller.notify(msg, args);
+					break;
+				}
+
 				case m.AccountCreateStatus:
 				case m.UserNameUpdateStatus:
 				case m.UserAvatarUpdateStatus:
 				case m.UserInfoStatus:
 				case m.CreateRequestStatus:
+				case m.GroupLoaded:
+				case m.GroupStatus:
 				{
 					controller.notify(msg, args);
 					break;
@@ -56,10 +82,38 @@ define(function(require, exports, module)
 			return null;
 		};
 
-		this.cmd = function(method, args)
+		this.cmd = function(cmd, args)
 		{
-			switch (method)
+			switch (cmd)
 			{
+				case rl.hasAccount:
+				{
+					return account.hasAccount();
+				}
+
+				case r.addGroup:
+				{
+					if (!groupController)
+					{
+						groupController = new GroupController(this, cfg);
+					}
+
+					groupController.cmd(cmd, args);
+					break;
+				}
+
+				case r.removeGroup:
+				{
+					console.log('ERROR: removeGroup() interface NOT_IMPL');
+					break;
+				}
+
+				case r.getGroup:
+				{
+					console.log('ERROR: getGroup() interface NOT_IMPL');
+					break;
+				}
+
 				case rl.accountCreate:
 				{
 					account.create();
@@ -88,11 +142,6 @@ define(function(require, exports, module)
 				{
 					account.getUserInfo(args);
 					break;
-				}
-
-				case rl.hasAccount:
-				{
-					return account.hasAccount();
 				}
 
 				case rl.createRequest:

--- a/app/src/adapter/Host.js
+++ b/app/src/adapter/Host.js
@@ -81,7 +81,7 @@ define(function(require, exports, module)
 			//port = sandbox.capabilities[Defines.PORT];
 
 			dbg('clientConnected: "' + data.id + '" v(' + data.version + ')');
-			var interfaceTypes = [ 'map', 'card', 'ext', 'app' ];
+			var interfaceTypes = [ 'map', 'card', 'core', 'ext', 'app' ];
 
 			// Generate API endpoints on main GA instance based on
 			// the advertised interfaces from the client
@@ -89,7 +89,6 @@ define(function(require, exports, module)
 			{
 				var intType = interfaceTypes[i];
 				var interfaces = (data && data[intType]);
-
 
 				if (interfaces)
 				{

--- a/app/src/adapter/PublicGroupController.js
+++ b/app/src/adapter/PublicGroupController.js
@@ -119,7 +119,7 @@ define(function(require, exports, module)
 
 			if (groups[name])
 			{
-				dbg('[PGController]: ERROR group "' + name + '" already loaded');
+				dbg('ERROR group "' + name + '" already loaded');
 				return;
 			}
 
@@ -158,11 +158,9 @@ define(function(require, exports, module)
 
 		function accountInitComplete(args)
 		{
-			var sig = '[PublicGroup#accountInitComplete] - ';
-
 			if (!account)
 			{
-				dbg(sig + 'authToken unavailable', args);
+				dbg('[accountInitComplete] - authToken unavailable', args);
 				return;
 			}
 

--- a/app/src/adapter/PublicGroupController.js
+++ b/app/src/adapter/PublicGroupController.js
@@ -75,7 +75,7 @@ define(function(require, exports, module)
 			{
 				case r.addGroup:
 				{
-					console.log('addGroup: ', args);
+					dbg('addGroup: ', args);
 
 					if (account)
 					{
@@ -89,7 +89,7 @@ define(function(require, exports, module)
 
 				default:
 				{
-					dbg('method not found', cmd);
+					dbg('Unknown cmd: "' + cmd + '" - ', args);
 					break;
 				}
 			}
@@ -119,7 +119,7 @@ define(function(require, exports, module)
 
 			if (groups[name])
 			{
-				console.log('[PGController]: ERROR group "' + name + '" already loaded');
+				dbg('[PGController]: ERROR group "' + name + '" already loaded');
 				return;
 			}
 

--- a/app/src/adapter/models/PublicGroup.js
+++ b/app/src/adapter/models/PublicGroup.js
@@ -115,13 +115,14 @@ define(function(require, exports, module)
 
 		function sendStatus(result, invitesAdded, invitesRemoved, invitesSwapped)
 		{
+			result.group = groupName;
+			
 			// Only send an update if some invite status is found
 			if (!(invitesAdded.length > 0 || invitesRemoved.length > 0 || invitesSwapped.length > 0))
 			{
 				return;
 			}
 
-			result.group = groupName;
 			result.invitesAdded = invitesAdded;
 			result.invitesRemoved = invitesRemoved;
 			result.invitesSwapped = invitesSwapped;

--- a/app/src/adapter/models/PublicGroup.js
+++ b/app/src/adapter/models/PublicGroup.js
@@ -32,15 +32,31 @@ define(function(require, exports, module)
 		var loaded = false;
 		var next = 0;
 		var lastUpdate = 0;
-
-		var inviteGroup = [];
+		var demoGroup = PublicGroup._DemoGroups[groupName.toString().toLowerCase()];
 		var users = [];
-		var inviteRemove = [];
 
 		var that = this;
 
-		this.getTicketGroup = function () { return inviteGroup; };
-		this.getInviteRemove = function () { return inviteRemove; };
+
+		///////////////////////////////////////////////////////////////////////////////
+		// PROPERTIES
+		///////////////////////////////////////////////////////////////////////////////
+
+		this.getUsers = function()
+		{
+			return users;
+		};
+
+		this.getInvites = function()
+		{
+			for (var i = users.length - 1, invites = []; i >= 0; i--)
+			{
+				invites.push(users[i].invite);
+			}
+
+			return invites;
+		};
+
 
 		///////////////////////////////////////////////////////////////////////////////
 		// PUBLIC
@@ -53,100 +69,101 @@ define(function(require, exports, module)
 
 		this.setData = function(data)
 		{
-			if (!data)
+			if (data)
 			{
-				return;
+				return processGroupInitial({ status: true, response: data, time: Date.now() });
 			}
-			return processGroupInitial({
-				status: true,
-				response: data,
-				time: Date.now()
-			});
 		};
 
+
 		///////////////////////////////////////////////////////////////////////////////
-		// PRIVATE MEMBERS
+		// UTILITY
 		///////////////////////////////////////////////////////////////////////////////
 
 		function requestGroup()
 		{
-			var noPolling = false;
-
-			var demoGroup = PublicGroup._DemoGroups[groupName.toString().toLowerCase()];
-
 			if (!loaded)
 			{
 				//console.log('::: :: INITIAL REQUEST :: ::: -- ' + idGroup);
-
 				if (demoGroup)
 				{
-					// do not poll demo groups
-					noPolling = true;
-
 					raf.setTimeout(function()
 					{
 						processGroupInitial(demoGroup);
 					}, 200);
+
+					return true;	// do not poll demo groups
 				}
-				else
-				{
-					ajax.get(svr + urlInitial, urlInitialParams, account)
-						.then(processGroupInitial);
-				}
+
+				ajax.get(svr + urlInitial, urlInitialParams, account)
+					.then(processGroupInitial);
+
+				return false;
 			}
-			// do not poll demo groups
-			else
+
+			if (demoGroup)
 			{
-				if (demoGroup)
-				{
-					// do not poll demo groups
-					noPolling = true;
-				}
-				else
-				{
-					//console.log('::: :: EVENTS REQUEST :: :::');
-
-					ajax.get(svr + urlEvents, { next: next }, account)
-						.then(processGroupUpdate);
-				}
+				return true;	// do not poll demo groups
 			}
 
-			return noPolling;
+			//console.log('::: :: EVENTS REQUEST :: :::');
+			ajax.get(svr + urlEvents, { next: next }, account)
+				.then(processGroupUpdate);
+
+			return false;
+		}
+
+		function sendStatus(result, invitesAdded, invitesRemoved, invitesSwapped)
+		{
+			// Only send an update if some invite status is found
+			if (!(invitesAdded.length > 0 || invitesRemoved.length > 0 || invitesSwapped.length > 0))
+			{
+				return;
+			}
+
+			result.group = groupName;
+			result.invitesAdded = invitesAdded;
+			result.invitesRemoved = invitesRemoved;
+			result.invitesSwapped = invitesSwapped;
+
+			controller.notify(m.GroupStatus, result);
 		}
 
 		// Parse returned initial Glympse Public Group results
 		function processGroupInitial(result)
 		{
-			inviteGroup = [];
-			loaded = true; // We're done, even if there is an error
+			loaded = true; // We're initialized, even if there is an error
+
+			var invitesAdded = [];
+			var invitesRemoved = [];
+			var invitesSwapped = [];
 
 			if (result.status)
 			{
-				parseGroupListResponse(result);
+				parseGroupListResponse(result, invitesAdded, invitesRemoved, invitesSwapped);
 			}
 
-			controller.notify(m.PG_RequestStatus, result);
-
-			//TODO: probably should sent it later, after all invites are ready
-			controller.notify(m.PG_Loaded, result);
+			sendStatus(result, invitesAdded, invitesRemoved, invitesSwapped);
+			controller.notify(m.GroupLoaded, result);
 		}
 
 		// Parse returned subsequent Glympse Public Group event results
 		function processGroupUpdate(result)
 		{
-			inviteGroup = [];
-			inviteRemove = [];
+			var invitesAdded = [];
+			var invitesRemoved = [];
+			var invitesSwapped = [];
+
 			loaded = true; // We're done, even if there is an error
 
 			//console.log('processGroupUpdate: got data: ' + data + ' -- ' + data.result);
 			if (result.status)
 			{
-
 				var o = result.response;
 
 				if (o.type === 'group')
 				{
-					parseGroupListResponse(result);
+					parseGroupListResponse(result, invitesAdded, invitesRemoved, invitesSwapped);
 				}
 				else //if (o.type === 'events')
 				{
@@ -166,28 +183,23 @@ define(function(require, exports, module)
 							{
 								var inv = item.invite;
 
-								if (item.type === 'swap')
-								{
-									console.log('GOT A SWAP -- member=' + item.member + ' -- invite=' + item.invite);
-								}
-
-								// Queue the new invite code for retrieval
-								dbg('ADD', inv);
-								inviteGroup.push(inv);
-
 								// See if we already have the user of the new 'invite'
 								user = findUser(item.member);
+
 								//console.log('[INVITE]member=' + item.member + '(found=' + (user != null) + ') oldInvite=' + (user && user.invite) + ', newInvite=' + inv);
 								if (user)
 								{
 									// If so, queue to remove the old invite and replace with the new one
-									dbg('REMOVE', user.invite);
-									inviteRemove.push(user.invite);
+									var swap = { user: u.id, invOld: user.invite, invNew: inv };
+									dbg('>> Invite swap: ', swap);
+									invitesSwapped.push(swap)
 									user.invite = inv;
 								}
 								else
 								{
 									// Otherwise, they are a new user to track
+									dbg('>> ADD: ', inv);
+									invitesAdded.push(inv);
 									users.push({ id: item.member, invite: inv });
 								}
 							}
@@ -198,8 +210,8 @@ define(function(require, exports, module)
 								user = findUser(item.member);
 								if (user)
 								{
-									dbg('REMOVE', user.invite);
-									inviteRemove.push(user.invite);
+									dbg('>> REMOVE: ', user.invite);
+									invitesRemoved.push(user.invite);
 									users.splice(users.indexOf(user), 1);
 								}
 							}
@@ -208,10 +220,10 @@ define(function(require, exports, module)
 				}
 			}
 
-			controller.notify(m.PG_RequestStatus, result);
+			sendStatus(result, invitesAdded, invitesRemoved, invitesSwapped);
 		}
 
-		function parseGroupListResponse(result)
+		function parseGroupListResponse(result, invitesAdded, invitesRemoved, invitesSwapped)
 		{
 			var i;
 			var o = result.response;
@@ -243,10 +255,10 @@ define(function(require, exports, module)
 							// Check if we have a new invite code for an existing user
 							if (u.invite !== m.invite)
 							{
-								dbg('ADD', m.invite);
-								inviteGroup.push(m.invite);
-								dbg('REMOVE', u.invite);
-								inviteRemove.push(u.invite);
+								var swap = { user: u.id, invOld: u.invite, invNew: m.invite };
+								dbg('** Invite swap: ', swap);
+								u.invite = m.invite;
+								invitesSwapped.push(swap)
 							}
 
 							// User still exists in the current list, so don't remove
@@ -258,8 +270,8 @@ define(function(require, exports, module)
 					// If not in the new list, remove the user
 					if (u)
 					{
-						dbg('REMOVE', u.invite);
-						inviteRemove.push(u.invite);
+						dbg('** REMOVE: ', u.invite);
+						invitesRemoved.push(u.invite);
 						users.splice(i, 1);
 					}
 				}
@@ -279,8 +291,8 @@ define(function(require, exports, module)
 					{
 						//console.log('id=' + cli.id + ', invite=' + cli.invite);
 						users.push(cli);
-						dbg('ADD', cli.invite);
-						inviteGroup.push(cli.invite);
+						dbg('** ADD: ', cli.invite);
+						invitesAdded.push(cli.invite);
 					}
 				}
 			}
@@ -288,17 +300,17 @@ define(function(require, exports, module)
 
 		function findUser(id)
 		{
-			for (var j = users.length - 1; j >= 0; j--)
+			for (var j = users.length - 1, userLocated = null; j >= 0; j--)
 			{
 				var user = users[j];
-
 				if (user.id === id)
 				{
-					return user;
+					userLocated = user;
+					break;
 				}
 			}
 
-			return null;
+			return userLocated;
 		}
 	}
 

--- a/app/src/lib/rafUtils.js
+++ b/app/src/lib/rafUtils.js
@@ -1,6 +1,8 @@
 define(function(require, exports, module)
 {
 	var w = window;
+	var g = w.glympse;
+	var glib = (g && g.lib);
 	var initted = false;
 
 	var performance = w.performance;
@@ -18,7 +20,7 @@ define(function(require, exports, module)
 		if (!initted)
 		{
 			initted = true;
-			var syncRaf = (glympse && glympse.lib && glympse.lib.syncRAF);
+			var syncRaf = (glib && glib.syncRAF);	// FIXME: Should centralize syncRAF here as well?
 			if (syncRaf)
 			{
 				syncRaf();
@@ -85,7 +87,7 @@ define(function(require, exports, module)
 		if (!initted)
 		{
 			initted = true;
-			var syncRaf = (glympse && glympse.lib && glympse.lib.syncRAF);
+			var syncRaf = (glib && glib.syncRAF);
 			if (syncRaf)
 			{
 				syncRaf();

--- a/app/src/test-client/src/ViewManager.js
+++ b/app/src/test-client/src/ViewManager.js
@@ -90,6 +90,69 @@ define(function(require, exports, module)
 					break;
 				}
 
+				case appMSG.GroupLoaded:
+				{
+					dbg('[ GroupLoaded ]: ', args);
+					dbg('Group id: ' + args.group);
+
+					if (args.error)
+					{
+						dbg('Error - ' + args.error + ' -- ' + args.errorDetail);
+					}
+					else
+					{
+						dbg('Invites [ADD]: (' + args.invitesAdded.length + ') ' + args.invitesAdded);
+						dbg('Invites [DEL]: (' + args.invitesRemoved.length + ') ' + args.invitesRemoved);
+						dbg('Invites [SWP]: (' + args.invitesSwapped.length + ') ' + args.invitesSwapped);
+					}
+
+					break;
+				}
+
+				case appMSG.GroupStatus:
+				{
+					dbg('[ GroupStatus ]: ', args);
+					dbg('Group id: ' + args.group);
+
+					if (args.error)
+					{
+						dbg('Error - ' + args.error + ' -- ' + args.errorDetail);
+						break;
+					}
+
+					dbg('Invites [ADD]: (' + args.invitesAdded.length + ') ' + args.invitesAdded);
+					dbg('Invites [DEL]: (' + args.invitesRemoved.length + ') ' + args.invitesRemoved);
+					dbg('Invites [SWP]: (' + args.invitesSwapped.length + ') ' + args.invitesSwapped);
+
+					var map = cfg.adapter.map;
+					var dInvites = args.invitesRemoved;
+
+					if (dInvites.length > 0)
+					{
+						map.removeInvites(dInvites.join(';'));
+					}
+
+					dInvites = args.invitesAdded;
+					if (dInvites.length > 0)
+					{
+						map.addInvites(dInvites.join(';'));
+					}
+
+					dInvites = args.invitesSwapped;
+					if (dInvites.length > 0)
+					{
+						for (var i = dInvites.length - 1; i >= 0; i--)
+						{
+							// FIXME: Do the real swap in the viewer to maintain stuff like
+							// history trails across invite changes for a user
+							map.addInvites(dInvites[i].invNew);
+							map.removeInvites(dInvites[i].invOld);
+						}
+					}
+
+					break;
+				}
+
 				default:
 				{
 					dbg('cmd() - unknown cmd: "' + cmd + '"', args);

--- a/app/src/test-host/src/ViewManager.js
+++ b/app/src/test-host/src/ViewManager.js
@@ -142,6 +142,24 @@ define(function(require, exports, module)
 			}
 		}
 
+		function doInputCore(method, output)
+		{
+			var val = input.val();
+			if (val)
+			{
+				cfg.adapter.core[method](val).then(function(data)
+				{
+					logEvent('[' + output + '] val=' + val, data);
+				});
+
+				input.val('');
+			}
+			else
+			{
+				logEvent('[' + output + '] ERROR: Need input!');
+			}
+		}
+
 		function clearOutput()
 		{
 			outputText.empty();
@@ -198,6 +216,15 @@ define(function(require, exports, module)
 			};
 		}
 
+		function generateInputCore(targ, output)
+		{
+			return function()
+			{
+				doInputCore(targ, output);
+			};
+		}
+
+
 		///////////////////////////////////////////////////////////////////////////
 		// CALLBACKS
 		///////////////////////////////////////////////////////////////////////////
@@ -223,7 +250,7 @@ define(function(require, exports, module)
 
 		// Commands
 		$('#addInvite').click(generateInput('addInvites', 'AddInvites'));
-		$('#addGroup').click(generateInput('addGroups', 'AddGroups'));
+		$('#addGroup').click(generateInputCore('addGroup', 'addGroup'));
 		$('#addTopic').click(generateInput('addTwitterTopics', 'AddTwitterTopics'));
 		$('#addUser').click(generateInput('addTwitterUsers', 'AddTwitterUsers'));
 		$('#removeInvite').click(generateInput('removeInvites', 'RemoveInvites'));


### PR DESCRIPTION
- Moved PublicGroups handling under the “core” base interface
- Added support for loading multiple public groups
- Refactored various naming/strings
- Stubbed removeGroup and getGroup commands
- Added event/endpoint info to README.md
- Centralized group polling (really need to batch them instead)
- Don’t send updates from a group unless it has some change in invite/user membership
- Pass up only changes in invites from a “GroupStatus” event update

Note that journey-shuttle will need to sync to the "groups-updates" branch to properly consume these updates.

@Glympse/web PTAL