### PR TITLE
FE-852: [adapter] Fetch org objects:

### DIFF
--- a/app/src/adapter/PublicGroupController.js
+++ b/app/src/adapter/PublicGroupController.js
@@ -245,11 +245,13 @@ define(function(require, exports, module)
 					hierarchy: [],
 					org_id: -999,
 					//TODO: does it make sense to generate waypoints based on passed `appCfg.areaDestinations`?
-					// smth like `appCfg.areaDestinations.slice(1).reverse()`
+					// smth like `appCfg.areaDestinations.slice(0).reverse()`
+					// Last location is base (at least for now)
 					waypoints: [
 						{ name: 'LAX Terminal #1', lat: 33.9451076, lng: -118.4032515 }
 						, { name: 'LAX Terminal #3 Lower Level FlyAway Stop', lat: 33.9438901, lng: -118.4060479 }
 						, { name: 'LAX Terminal #5 Lower Level FlyAway Stop', lat: 33.9426841, lng: -118.4046578 }
+						, { name: 'Holiday Inn Los Angeles Gateway - Torrance, 19800 S Vermont Ave, Torrance, CA 90502, USA', lat: 33.8507901, lng: -118.306608 }
 					],
 					last_modified_by: 0,
 					group_name: 'demoshuttle',

--- a/app/src/adapter/PublicGroupController.js
+++ b/app/src/adapter/PublicGroupController.js
@@ -20,6 +20,8 @@ define(function(require, exports, module)
 		var dbg = lib.dbg('PublicGroupController', cfg.dbg);
 		var svr = cfg.svcEnRoute;
 
+		var cDemoOrgObjects = {};
+
 		var PG_POLL_INTERVAL = 15000;
 
 		// state
@@ -177,6 +179,14 @@ define(function(require, exports, module)
 				return;
 			}
 
+			var demoObjects = cDemoOrgObjects[reqParams.orgId];
+			if (demoObjects)
+			{
+				controller.notify(m.OrgObjects, demoObjects);
+
+				return;
+			}
+
 			var url = svr + 'org/' + reqParams.orgId + '/objects';
 			var data;
 
@@ -227,6 +237,32 @@ define(function(require, exports, module)
 				timerRequest = null;
 			}
 		}
+
+		cDemoOrgObjects[-999] = {
+			status: true,
+			response: [
+				{
+					hierarchy: [],
+					org_id: -999,
+					//TODO: does it make sense to generate waypoints based on passed `appCfg.areaDestinations`?
+					// smth like `appCfg.areaDestinations.slice(1).reverse()`
+					waypoints: [
+						{ name: 'LAX Terminal #1', lat: 33.9451076, lng: -118.4032515 }
+						, { name: 'LAX Terminal #3 Lower Level FlyAway Stop', lat: 33.9438901, lng: -118.4060479 }
+						, { name: 'LAX Terminal #5 Lower Level FlyAway Stop', lat: 33.9426841, lng: -118.4046578 }
+					],
+					last_modified_by: 0,
+					group_name: 'demoshuttle',
+					access: 'public',
+					last_modified: 1498017300352,
+					created_time: 1498017215788,
+					creator_agent_id: 0,
+					_id: 2,
+					type: 'route'
+				}
+			],
+			time: Date.now()
+		};
 	}
 
 	module.exports = PublicGroupController;

--- a/app/src/adapter/models/PublicGroup.js
+++ b/app/src/adapter/models/PublicGroup.js
@@ -11,6 +11,8 @@ define(function(require, exports, module)
 
 	var m = Defines.MSG;
 
+	var cDemoGroups;
+
 	// Exported class
 	function PublicGroup(controller, account, groupName, cfg)
 	{
@@ -32,7 +34,7 @@ define(function(require, exports, module)
 		var loaded = false;
 		var next = 0;
 		var lastUpdate = 0;
-		var demoGroup = PublicGroup._DemoGroups[groupName.toString().toLowerCase()];
+		var demoGroup = cDemoGroups[groupName.toString().toLowerCase()];
 		var users = [];
 
 		var that = this;
@@ -315,7 +317,7 @@ define(function(require, exports, module)
 		}
 	}
 
-	PublicGroup._DemoGroups = {
+	cDemoGroups = {
 		bryanaroundseattle: {
 			status: true,
 			response: {
@@ -359,7 +361,10 @@ define(function(require, exports, module)
 					{ id: 'DNA7-4HDZ-03WH0', invite: 'demobot0' }
 				],
 				public: true,
-				name: 'DemoShuttle'
+				name: 'DemoShuttle',
+				branding: {
+					org_id: -999
+				}
 			},
 			time: Date.now()
 		}

--- a/app/src/lib/ajax.js
+++ b/app/src/lib/ajax.js
@@ -18,14 +18,14 @@ define(function(require, exports, module)
 	{
 		var result = null;
 
-		if (data && data.response)
+		if (data && (data.response || data.body))
 		{
 			result = { status: false, response: {} };
 
 			if (data.result === 'ok')
 			{
 				result.status = true;
-				result.response = data.response;
+				result.response = (data.response || data.body);
 				result.time = data.meta && data.meta.time;
 			}
 


### PR DESCRIPTION
- fixed response parser: api response can have `body` prop instead of `response`
- added demo org objects response for `orgId=-999`

@Glympse/web, PTAL.

@j5kay, @egorpushkin, is home (base) location should be the part of `waypoints`, or how will we get it in the journey app (anon token)?