### PR TITLE
FE-860 Add setting of appName/appVersion to viewer

### DIFF
--- a/app/src/GlympseAdapter.js
+++ b/app/src/GlympseAdapter.js
@@ -30,6 +30,7 @@ define(function(require, exports, module)
 
 		var cfgApp = (cfg && cfg.app) || {};
 		var cfgAdapter = (cfg && cfg.adapter) || {};
+		var cfgViewer = (cfg && cfg.viewer) || {};
 		var dbg = lib.dbg(adapterLabel, cfgApp.dbg);
 
 		var client;			// client mode
@@ -40,6 +41,12 @@ define(function(require, exports, module)
 
 		var glympserLoader = null;
 		var version = VersionInfo.version;
+
+		if (cfgAdapter.appName && cfgAdapter.appVersion && !cfgViewer.appName && !cfgViewer.appVersion)
+		{
+			cfgViewer.appName = cfgAdapter.appName;
+			cfgViewer.appVersion = cfgAdapter.appVersion;
+		}
 
 		cfgAdapter.appName = cfgAdapter.appName || adapterLabel;
 		cfgAdapter.appVersion = cfgAdapter.appVersion || version;


### PR DESCRIPTION
FE-860 https://jira.glympse.com/browse/FE-860

Sets these properties only if viewer is missing both
and adapter has both.

Testing requires the latest viewer currently on /dev/ (and either https://github.com/Glympse/enroute-journey/pull/178 or https://github.com/Glympse/web-app-viewer/pull/507)

@Glympse/web PTAL