### PR TITLE
New params for demo-mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ var cfg =
     - `maxSize`: Max size for avatar image scaling
   - `appName` - Name of the hosting application
   - `appVersion` - Version of the hosting application
+  - `demoDriversCount` - The number of drivers to return in `demoshuttle` group. Min=0 and Max=7.
+  - `demoWaypoints` - The list of waypoints which should be returned for the demo org object. 
+  The format is `[ { name: 'Stop #1', lat: 123, lng: -123 }, ... ]`. The last point is base org location.
 
 ### Custom Marker Configuration
 For the `addMarkers(cfgMarkers)` API, the `cfgMarkers` object is of the following

--- a/app/src/adapter/PublicGroupController.js
+++ b/app/src/adapter/PublicGroupController.js
@@ -339,15 +339,7 @@ define(function(require, exports, module)
 				{
 					hierarchy: [],
 					org_id: -999,
-					//TODO: does it make sense to generate waypoints based on passed `appCfg.areaDestinations`?
-					// smth like `appCfg.areaDestinations.slice(0).reverse()`
-					// Last location is base (at least for now)
-					waypoints: [
-						{ name: 'LAX Terminal #1', lat: 33.9451076, lng: -118.4032515 }
-						, { name: 'LAX Terminal #3 Lower Level FlyAway Stop', lat: 33.9438901, lng: -118.4060479 }
-						, { name: 'LAX Terminal #5 Lower Level FlyAway Stop', lat: 33.9426841, lng: -118.4046578 }
-						, { name: 'Holiday Inn Los Angeles Gateway - Torrance, 19800 S Vermont Ave, Torrance, CA 90502, USA', lat: 33.8507901, lng: -118.306608 }
-					],
+					waypoints: cfg.demoWaypoints || [],
 					last_modified_by: 0,
 					group_name: 'demoshuttle',
 					access: 'public',

--- a/app/src/adapter/PublicGroupController.js
+++ b/app/src/adapter/PublicGroupController.js
@@ -339,7 +339,12 @@ define(function(require, exports, module)
 				{
 					hierarchy: [],
 					org_id: -999,
-					waypoints: cfg.demoWaypoints || [],
+					waypoints: cfg.demoWaypoints || [
+						{ name: 'LAX Terminal #5', lat: 33.9426841, lng: -118.4046578 },
+						{ name: 'LAX Terminal #3', lat: 33.9438901, lng: -118.4060479 },
+						{ name: 'LAX Terminal #1', lat: 33.9451076, lng: -118.4032515 },
+						{ name: 'Holiday Inn Los Angeles Gateway', lat: 33.8507901, lng: -118.306608 }
+					],
 					last_modified_by: 0,
 					group_name: 'demoshuttle',
 					access: 'public',

--- a/app/src/adapter/models/PublicGroup.js
+++ b/app/src/adapter/models/PublicGroup.js
@@ -330,6 +330,19 @@ define(function(require, exports, module)
 
 			return userLocated;
 		}
+
+
+		// Fill demoshuttle drivers
+		if (cfg.demoDriversCount)
+		{
+			// Allowed range is [0-7]
+			var driversCount = Math.max(0, Math.min(cfg.demoDriversCount, 7));
+			var demoshuttleMembers = cDemoGroups.demoshuttle.response.members;
+			for (var i = driversCount - 1; i >= 0; i--)
+			{
+				demoshuttleMembers.push({ id: 'DNA7-4HDZ-03WH' + i, invite: 'demobot' + i })
+			}
+		}
 	}
 
 	cDemoGroups = {
@@ -372,9 +385,7 @@ define(function(require, exports, module)
 				type: 'group',
 				id: 119,
 				events: 1,
-				members: [
-					{ id: 'DNA7-4HDZ-03WH0', invite: 'demobot0' }
-				],
+				members: [],
 				public: true,
 				name: 'DemoShuttle',
 				branding: {


### PR DESCRIPTION
  - `demoWaypoints`
  - `demoDriversCount`

@Glympse/web, PTAL.