### PR TITLE
FE-960: [adapter] Add get ETA API to the adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 version |date        |notes
 :-------|:-----------|:------
-2.8.x   | 2017/07/?? | BugFix for auth requests. New `core.getETAInfo` endpoint + `ETAInfo` event.
+2.9.0   | 2017/07/?? | BugFix for auth requests. New `core.getEtaInfo` endpoint + `EtaInfo` event.
 2.8.1   | 2017/07/19 | New `ViewerZoomChanged` event + bot group options
 2.7.2   | 2017/07/17 | Missing auth / removed ticket invite bugfixes
 2.7.1   | 2017/07/12 | Propagate app info through to viewer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 version |date        |notes
 :-------|:-----------|:------
+2.8.x   | 2017/07/?? | BugFix for auth requests. New `core.getETAInfo` endpoint + `ETAInfo` event.
 2.8.1   | 2017/07/19 | New `ViewerZoomChanged` event + bot group options
 2.7.2   | 2017/07/17 | Missing auth / removed ticket invite bugfixes
 2.7.1   | 2017/07/12 | Propagate app info through to viewer

--- a/README.md
+++ b/README.md
@@ -526,6 +526,8 @@ using GA in host-mode) that are sent by the adapter (defined in the
   - `n`: Property id
   - `v`: Property value (may be default type, or a custom Object with additional
   members)
+- `ETAInfo`: Generates when ETA info was fetched in response to `getETAInfo` request to the `core` endpoint, 
+  with information the loaded ETAs. The order in array the same as in request args.
 - `GroupLoaded`: Generated after an `addGroup` command is sent to the `core` endpoint, with information
   about the just-loaded Glympse public group. For normal responses, the `args` payload will look something
   like:
@@ -774,6 +776,17 @@ specified in `GlympseAdapterDefines.CORE.REQUESTS`.
 - `addGroup(groupInfo: string|object)`: Creates a Glympse "public" group request for viewing.
   `groupInfo` can specify the group id to load (if it is a string type), or the response of
   an initial groups request (if it is an object type).
+- `getETAInfo(routes)`: Request the ETAs for specific routes. The routes format is
+    ```
+    [
+        { 
+            start: { lat: number, lng: number }, // start point of the route 
+            end: { lat: number, lng: number }    // end point of the route
+        },
+        ...
+    ]
+    ```
+  Results will be returned as `ETAInfo` event. The order of ETAs in results will be the same as in request agrs.
 - `getGroups(null|groupId: string|[group_1,group_2,...]: Array)`: Returns a list of monitored
   Glympse public groups, based on the given input param (specified below). Returns an array
   of all matched groups, each containing current ticket invite and user information.

--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ using GA in host-mode) that are sent by the adapter (defined in the
   - `n`: Property id
   - `v`: Property value (may be default type, or a custom Object with additional
   members)
-- `ETAInfo`: Generates when ETA info was fetched in response to `getETAInfo` request to the `core` endpoint, 
+- `EtaInfo`: Generates when ETA info was fetched in response to `getEtaInfo` request to the `core` endpoint, 
   with information the loaded ETAs. The order in array the same as in request args.
 - `GroupLoaded`: Generated after an `addGroup` command is sent to the `core` endpoint, with information
   about the just-loaded Glympse public group. For normal responses, the `args` payload will look something
@@ -776,7 +776,7 @@ specified in `GlympseAdapterDefines.CORE.REQUESTS`.
 - `addGroup(groupInfo: string|object)`: Creates a Glympse "public" group request for viewing.
   `groupInfo` can specify the group id to load (if it is a string type), or the response of
   an initial groups request (if it is an object type).
-- `getETAInfo(routes)`: Request the ETAs for specific routes. The routes format is
+- `getEtaInfo(routes)`: Request the ETAs for specific routes. The routes format is
     ```
     [
         { 
@@ -786,7 +786,7 @@ specified in `GlympseAdapterDefines.CORE.REQUESTS`.
         ...
     ]
     ```
-  Results will be returned as `ETAInfo` event. The order of ETAs in results will be the same as in request agrs.
+  Results will be returned as `EtaInfo` event. The order of ETAs in results will be the same as in request agrs.
 - `getGroups(null|groupId: string|[group_1,group_2,...]: Array)`: Returns a list of monitored
   Glympse public groups, based on the given input param (specified below). Returns an array
   of all matched groups, each containing current ticket invite and user information.

--- a/app/src/GlympseAdapterDefines.js
+++ b/app/src/GlympseAdapterDefines.js
@@ -95,7 +95,7 @@ define(function(require, exports, module)
 				, getGroups: 'getGroups'
 				, removeGroup: 'removeGroup'
 				, getOrgObjects: 'getOrgObjects'
-				, getETAInfo: 'getETAInfo'
+				, getEtaInfo: 'getEtaInfo'
 			}
 
 
@@ -154,7 +154,7 @@ define(function(require, exports, module)
 			, GroupStatus: 'GroupStatus'
 			, OrgObjects: 'OrgObjects'
 
-			, ETAInfo: 'ETAInfo'
+			, EtaInfo: 'EtaInfo'
 
 			, DataUpdate: 'DataUpdate'
 			, InviteAdded: 'InviteAdded'

--- a/app/src/GlympseAdapterDefines.js
+++ b/app/src/GlympseAdapterDefines.js
@@ -95,6 +95,7 @@ define(function(require, exports, module)
 				, getGroups: 'getGroups'
 				, removeGroup: 'removeGroup'
 				, getOrgObjects: 'getOrgObjects'
+				, getETAInfo: 'getETAInfo'
 			}
 
 
@@ -152,6 +153,8 @@ define(function(require, exports, module)
 			, GroupLoaded: 'GroupLoaded'
 			, GroupStatus: 'GroupStatus'
 			, OrgObjects: 'OrgObjects'
+
+			, ETAInfo: 'ETAInfo'
 
 			, DataUpdate: 'DataUpdate'
 			, InviteAdded: 'InviteAdded'

--- a/app/src/adapter/Client.js
+++ b/app/src/adapter/Client.js
@@ -547,6 +547,7 @@ define(function(require, exports, module)
 				case m.GroupLoaded:
 				case m.GroupStatus:
 				case m.OrgObjects:
+				case m.EtaInfo:
 				{
 					sendEvent(msg, args);
 					break;

--- a/app/src/adapter/CoreController.js
+++ b/app/src/adapter/CoreController.js
@@ -4,6 +4,7 @@ define(function(require, exports, module)
 
 	// defines
 	var lib = require('glympse-adapter/lib/utils');
+	var ajax = require('glympse-adapter/lib/ajax');
 	var Defines = require('glympse-adapter/GlympseAdapterDefines');
 
 	var m = Defines.MSG;
@@ -19,6 +20,8 @@ define(function(require, exports, module)
 	{
 		// consts
 		var dbg = lib.dbg('CoreController', cfg.dbg);
+
+		var svr = cfg.svcGlympse;
 
 		// state
 		var account = new Account(this, cfg);
@@ -161,6 +164,12 @@ define(function(require, exports, module)
 					account.delete();
 					break;
 				}
+
+				case r.getETAInfo:
+				{
+					getETAInfo(args);
+					break;
+				}
 			}
 		};
 
@@ -173,6 +182,72 @@ define(function(require, exports, module)
 		///////////////////////////////////////////////////////////////////////////////
 		// UTILITY
 		///////////////////////////////////////////////////////////////////////////////
+
+		/**
+		 * Fetch ETA information to the given points
+		 *
+		 * @param {Object[]} routes - array of routes for which to calculate ETAs.
+		 *	Each object must has the following properties:
+		 *	- "start" - is a starting point in format { lat: number, lng: number }
+		 *	- "end" - is an ending point in format { lat: number, lng: number }
+		 */
+		function getETAInfo(routes)
+		{
+			if (!routes || !routes.length)
+			{
+				dbg('ETA Info: no routes provided, nothing to calculate');
+
+				controller.notify(m.ETAInfo, {
+					status: true,
+					result: []
+				});
+
+				return;
+			}
+
+			var routeUrl = 'maps/route?';
+			var requests = [];
+			var route, start, end, params;
+
+			for (var i = 0, len = routes.length; i < len; i++)
+			{
+				route = routes[i];
+				start = route.start;
+				end = route.end;
+				params = {
+					start: start.lat + ',' + start.lng,
+					end: end.lat + ',' + end.lng,
+					fields: 'summary'
+				};
+				requests.push({
+					method: 'GET',
+					url: routeUrl + $.param(params)
+				});
+			}
+
+			ajax.batch(svr + 'batch', requests, account)
+				.then(function(responses)
+				{
+					var result = [];
+					var res, eta;
+					for (var i = 0, len = responses.length; i < len; i++)
+					{
+						res = (responses[i] || {}).result;
+						eta = null;
+
+						if (res.status)
+						{
+							eta = (((res.response || {}).summary || {}).travel_time || 0);
+						}
+
+						result.push(eta);
+					}
+
+					dbg('> ETA results:', result);
+
+					controller.notify(m.ETAInfo, result);
+				});
+		}
 
 	}
 

--- a/app/src/adapter/CoreController.js
+++ b/app/src/adapter/CoreController.js
@@ -165,9 +165,9 @@ define(function(require, exports, module)
 					break;
 				}
 
-				case r.getETAInfo:
+				case r.getEtaInfo:
 				{
-					getETAInfo(args);
+					getEtaInfo(args);
 					break;
 				}
 			}
@@ -191,13 +191,13 @@ define(function(require, exports, module)
 		 *	- "start" - is a starting point in format { lat: number, lng: number }
 		 *	- "end" - is an ending point in format { lat: number, lng: number }
 		 */
-		function getETAInfo(routes)
+		function getEtaInfo(routes)
 		{
 			if (!routes || !routes.length)
 			{
 				dbg('ETA Info: no routes provided, nothing to calculate');
 
-				controller.notify(m.ETAInfo, {
+				controller.notify(m.EtaInfo, {
 					status: true,
 					result: []
 				});
@@ -245,7 +245,7 @@ define(function(require, exports, module)
 
 					dbg('> ETA results:', result);
 
-					controller.notify(m.ETAInfo, result);
+					controller.notify(m.EtaInfo, result);
 				});
 		}
 

--- a/app/src/lib/ajax.js
+++ b/app/src/lib/ajax.js
@@ -154,6 +154,7 @@ define(function(require, exports, module)
 		makeRequest: function makeRequest(jqOptions, auth, retryOnError)
 		{
 			var account;
+			var useHeader;
 			var authHeaderPrefix;
 			var options = $.extend({}, DEFAULT_OPTIONS.ALL, jqOptions);
 
@@ -162,17 +163,19 @@ define(function(require, exports, module)
 				if (auth.account)
 				{
 					account = auth.account;
-
 					// TRUE if not exact FALSE is passed
-					if (auth.useHeader !== false)
-					{
-						// Two definable types of auth headers..
-						authHeaderPrefix = (auth.useGlympseAuthHeader === true) ? 'Glympse ' : 'Bearer ';
-					}
+					useHeader = (auth.useHeader !== false);
 				}
 				else
 				{
 					account = auth;
+					useHeader = true;
+				}
+
+				if (useHeader)
+				{
+					// Two definable types of auth headers..
+					authHeaderPrefix = (auth.useGlympseAuthHeader === true) ? 'Glympse ' : 'Bearer ';
 				}
 			}
 
@@ -183,7 +186,7 @@ define(function(require, exports, module)
 				attempts: ((retryOnError === false) ? 1 : MAX_ATTEMPTS),
 				retry: function()
 				{
-					var token = (account && account.getToken())
+					var token = (account && account.getToken());
 					if (token)
 					{
 						addAuthData(authHeaderPrefix, token, options);

--- a/app/src/test-client/src/Main.js
+++ b/app/src/test-client/src/Main.js
@@ -43,6 +43,22 @@ define(function(require, exports, module)
 					dbg('--> ADAPTER READY', args);
 					invitesCard = args.cards;
 					invitesGlympse = args.glympses;
+
+					// adapter.core.getETAInfo([
+					// 	{
+					// 		start: { name: 'Holiday Inn Los Angeles Gateway', lat: 33.8507901, lng: -118.306608 },
+					// 		end: { name: 'LAX Terminal #1', lat: 33.9451076, lng: -118.4032515 }
+					// 	},
+					// 	{
+					// 		start: { name: 'LAX Terminal #1', lat: 33.9451076, lng: -118.4032515 },
+					// 		end: { name: 'LAX Terminal #3', lat: 33.9438901, lng: -118.4060479 }
+					// 	},
+					// 	{
+					// 		start: { name: 'LAX Terminal #3', lat: 33.9438901, lng: -118.4060479 },
+					// 		end: { name: 'Holiday Inn Los Angeles Gateway', lat: 33.8507901, lng: -118.306608 }
+					// 	}
+					// ]);
+
 					break;
 				}
 

--- a/app/src/test-client/src/Main.js
+++ b/app/src/test-client/src/Main.js
@@ -43,22 +43,6 @@ define(function(require, exports, module)
 					dbg('--> ADAPTER READY', args);
 					invitesCard = args.cards;
 					invitesGlympse = args.glympses;
-
-					// adapter.core.getETAInfo([
-					// 	{
-					// 		start: { name: 'Holiday Inn Los Angeles Gateway', lat: 33.8507901, lng: -118.306608 },
-					// 		end: { name: 'LAX Terminal #1', lat: 33.9451076, lng: -118.4032515 }
-					// 	},
-					// 	{
-					// 		start: { name: 'LAX Terminal #1', lat: 33.9451076, lng: -118.4032515 },
-					// 		end: { name: 'LAX Terminal #3', lat: 33.9438901, lng: -118.4060479 }
-					// 	},
-					// 	{
-					// 		start: { name: 'LAX Terminal #3', lat: 33.9438901, lng: -118.4060479 },
-					// 		end: { name: 'Holiday Inn Los Angeles Gateway', lat: 33.8507901, lng: -118.306608 }
-					// 	}
-					// ]);
-
 					break;
 				}
 


### PR DESCRIPTION
Also contains important fix for `ajax` util around auth header handling.

@Glympse/web, PTAL. 